### PR TITLE
Move dilepton ttbar reconstruction to the ttbarReco class 

### DIFF
--- a/interface/Event.h
+++ b/interface/Event.h
@@ -29,7 +29,6 @@
 
 #include "Analysis/CyMiniAna/interface/physicsObjects.h"
 #include "Analysis/CyMiniAna/interface/configuration.h"
-#include "Analysis/CyMiniAna/interface/dileptonTtbarReco.h"
 #include "Analysis/CyMiniAna/interface/truthMatching.h"
 #include "Analysis/CyMiniAna/interface/deepLearning.h"
 #include "Analysis/CyMiniAna/interface/ttbarReco.h"
@@ -111,7 +110,6 @@ class Event {
 
     // kinematic reconstruction, ML
     bool customIsolation( Lepton& lep );
-    void getDilepton();
     Ttbar0L ttbar0L() const {return m_ttbar0L;}
     Ttbar1L ttbar1L() const {return m_ttbar1L;}
     Ttbar2L ttbar2L() const {return m_ttbar2L;}
@@ -172,13 +170,6 @@ class Event {
     Ttbar0L m_ttbar0L;
     Ttbar1L m_ttbar1L;
     Ttbar2L m_ttbar2L;
-
-    // -- dilepton -- to be fixed
-    bool m_ee;
-    bool m_mumu;
-    bool m_emu;
-    dileptonTtbarReco* m_dileptonTtbar;
-    DileptonReco m_dilepton;
 
     // event weight information
     double m_nominal_weight;

--- a/interface/ttbarReco.h
+++ b/interface/ttbarReco.h
@@ -5,10 +5,10 @@
 #include <map>
 #include <vector>
 
+#include "Analysis/CyMiniAna/interface/physicsObjects.h"
 #include "Analysis/CyMiniAna/interface/tools.h"
 #include "Analysis/CyMiniAna/interface/configuration.h"
-#include "Analysis/CyMiniAna/interface/physicsObjects.h"
-
+#include "Analysis/CyMiniAna/interface/dileptonTtbarReco.h"
 
 class ttbarReco {
   public:
@@ -36,6 +36,9 @@ class ttbarReco {
     Ttbar0L m_ttbar0L;
     Ttbar1L m_ttbar1L;
     Ttbar2L m_ttbar2L;
+
+    dileptonTtbarReco* m_dileptonTtbar;
+    DileptonReco m_dilepton;
 
     std::map<std::string,int> m_mapContainment;
     std::map<std::string,int> m_targetMap;

--- a/src/Event.cxx
+++ b/src/Event.cxx
@@ -18,8 +18,7 @@ Event::Event( TTreeReader &myReader, configuration &cmaConfig ) :
   m_config(&cmaConfig),
   m_ttree(myReader),
   m_treeName("SetMe"),
-  m_fileName("SetMe"),
-  m_dileptonTtbar(nullptr){
+  m_fileName("SetMe"){
     m_isMC     = m_config->isMC();
     m_useTruth = m_config->useTruth();
     m_grid     = m_config->isGridFile();             // file directly from EDM->FlatNtuple step
@@ -320,8 +319,6 @@ void Event::clear(){
     m_btag_jets_default.clear();
     m_weight_btag_default = 1.0;
     m_nominal_weight = 1.0;
-
-    m_dilepton = {};
 
     m_HT = 0;
     m_ST = 0;
@@ -967,48 +964,6 @@ bool Event::customIsolation( Lepton& lep ){
 
 
 /*** GETTER FUNCTIONS ***/
-void Event::getDilepton(){
-    /* Organize information into struct */
-    m_dilepton = {};             // struct of information needed to build neutrinos
-
-    // Leptons
-    Lepton lepton_p;
-    Lepton lepton_n;
-    if (m_leptons.at(0).charge > 0){
-        lepton_p = m_leptons.at(0);
-        lepton_n = m_leptons.at(1);
-    }
-    else{
-        lepton_p = m_leptons.at(1);
-        lepton_n = m_leptons.at(0);
-    }
-
-    m_dilepton.lepton_pos = lepton_p;
-    m_dilepton.lepton_neg = lepton_n;
-
-    // MET
-    TVector2 dilep_met;
-    dilep_met.SetX( m_met.p4.X() );
-    dilep_met.SetY( m_met.p4.Y() );
-    m_dilepton.met = dilep_met;
-
-    // Jets
-    std::vector<Jet> bjets;
-    for (const auto& j : m_btag_jets_default){
-        bjets.push_back(m_jets.at(j));
-    }
-    m_dilepton.jets  = m_jets;
-    m_dilepton.bjets = bjets;
-
-    cma::DEBUG("EVENT : Dilepton");
-    cma::DEBUG("EVENT : met       = "+std::to_string(m_met.p4.Pt()));
-    cma::DEBUG("EVENT : lepton pT = "+std::to_string(m_leptons.at(0).p4.Pt()));
-    cma::DEBUG("EVENT : jet pT    = "+std::to_string(m_jets.at(0).p4.Pt()));
-
-    return;
-}
-
-
 void Event::getBtaggedJets( Jet& jet ){
     /* Determine the b-tagging */
     jet.isbtagged["L"] = false;
@@ -1163,7 +1118,6 @@ void Event::truth(){
 void Event::finalize(){
     // delete variables
     cma::DEBUG("EVENT : Finalize() ");
-    //delete m_dileptonTtbar;
     delete m_eventNumber;
     delete m_runNumber;
     delete m_lumiblock;

--- a/src/ttbarReco.cxx
+++ b/src/ttbarReco.cxx
@@ -1,6 +1,6 @@
 /*
-Created:        --
-Last Updated:   21 March 2018
+Created:        21 March 2018
+Last Updated:   16 May   2018
 
 Dan Marley
 daniel.edison.marley@cernSPAMNOT.ch
@@ -23,6 +23,9 @@ ttbarReco::ttbarReco( configuration& cmaConfig ) :
     m_ttbar0L = {};
     m_ttbar1L = {};
     m_ttbar2L = {};
+
+    if (m_config->isTwoLeptonAnalysis())
+        m_dileptonTtbar = new dileptonTtbarReco(cmaConfig, configuration::run2_13tev_2016_25ns, 2, true);
   }
 
 ttbarReco::~ttbarReco() {}
@@ -166,6 +169,8 @@ void ttbarReco::execute(std::vector<Lepton>& leptons, std::vector<Neutrino>& nu,
 
 // dilepton
 void ttbarReco::execute(std::vector<Electron>& electrons, std::vector<Muon>& muons, std::vector<Jet>& jets){
+    /* Dilepton ttbar reconstruction */
+    m_dileptonTtbar->execute(m_dilepton);
     return;
 }
 


### PR DESCRIPTION
Closes #23 

Dilepton information moved to `ttbarReco`, but still not really supported.