### PR TITLE
Change log plotting option to dictionary

### DIFF
--- a/python/deepLearningPlotter.py
+++ b/python/deepLearningPlotter.py
@@ -130,7 +130,7 @@ class DeepLearningPlotter(object):
 
             hist.normed  = True
             hist.stacked = False
-            hist.logplot = False
+            hist.logplot = {"y":False,"x":False,"data":False}
             hist.binning = binning
             hist.x_label = self.variable_labels[feature].label
             hist.y_label = "Events"
@@ -248,7 +248,7 @@ class DeepLearningPlotter(object):
             hist.saveAs  = "{0}/hist_DNN_prediction_kfold{1}_{2}".format(self.output_dir,i,self.date)
             hist.binning = [bb/10. for bb in range(11)]
             hist.stacked = False
-            hist.logplot = False
+            hist.logplot = {"y":False,"x":False,"data":False}
             hist.x_label = "Prediction"
             hist.y_label = "Arb. Units"
             hist.CMSlabel = 'top left'

--- a/python/hepPlotter/hepPlotterDataMC.py
+++ b/python/hepPlotter/hepPlotterDataMC.py
@@ -181,7 +181,7 @@ class HepPlotterDataMC(HepPlotter):
                                  weights=weights,histtype="stepfilled",
                                  edgecolor='k',ls="solid",color=fillcolors,
                                  label=labels,stacked=self.stacked,
-                                 log=self.logplot,zorder=10)
+                                 log=self.logplot["y"],zorder=10)
         self.histograms["background"]    = totalBckg[-1]          # total background prediction
         self.uncertainties["background"] = np.sqrt( totalErrors ) # stat errors added in quadrature
 
@@ -226,7 +226,7 @@ class HepPlotterDataMC(HepPlotter):
                         lw=2,edgecolor=signal_color,color=signal_color,
                         label=signal_label,
                         stacked=self.stackSignal,bottom=bottomEdge,
-                        log=self.logplot,zorder=11) # draw in front of background/behind data
+                        log=self.logplot["y"],zorder=11) # draw in front of background/behind data
             if max(signalPred) > totpred:
                 totpred = signalPred
             self.histograms[name]    = signalPred
@@ -258,7 +258,7 @@ class HepPlotterDataMC(HepPlotter):
                                             label=self.sample_labels[name].label)
             # Draw in the bottom plot
             systHist,b,p = self.ax2.hist(data,bins=binning,weights=weight,histtype='step',
-                                         lw=2,edgecolor=color,color=color,log=self.logplot,
+                                         lw=2,edgecolor=color,color=color,log=self.logplot["y"],
                                          label=self.sample_labels[name].label,
                                          stacked=False,zorder=10)
 
@@ -313,11 +313,11 @@ class HepPlotterDataMC(HepPlotter):
         # y-axis
         if self.ymaxScale is None:
             self.ymaxScale = self.yMaxScaleValues[self.typeOfPlot]
-        yminimum = 0.1 if self.logplot else 0.0
+        yminimum = 0.1 if self.logplot["y"] else 0.0
 
         self.ax1.set_ylim(yminimum,self.ymaxScale*self.ax1.get_ylim()[1])
         self.ax1.set_yticks(self.ax1.get_yticks()[1:])                  # remove the first point (overlaps with ratio plot)
-        if self.logplot: self.ax1.set_yticks(self.ax1.get_yticks()[1:]) # remove the first point (again)
+        if self.logplot["y"]: self.ax1.set_yticks(self.ax1.get_yticks()[1:]) # remove the first point (again)
         self.setYAxis(self.ax1)
 
         # x-axis

--- a/python/runDataMC.py
+++ b/python/runDataMC.py
@@ -93,7 +93,7 @@ for histogram in histograms:
     hist.stacked     = True        # stack backgrounds
     hist.binning     = None
     hist.rebin       = variables[histogramName].binning # rebin per histogram
-    hist.logplot     = False
+    hist.logplot     = {"y":False,"x":False,"data":False}
     hist.x_label     = variables[histogramName].label
     hist.y_label     = "Events"
     hist.lumi        = 'XY.Z'

--- a/python/runDataMC_ttbarAC.py
+++ b/python/runDataMC_ttbarAC.py
@@ -129,7 +129,6 @@ for histogram in histograms:
 
     xlimits = None
     legendLoc   = 1
-    plotLogAxis = False
 
     hist.drawStatUncertainty = True      # draw stat uncertainty separately
     hist.drawSystUncertainty = False     # draw syst uncertainty separately
@@ -142,7 +141,7 @@ for histogram in histograms:
     hist.ratio_type  = "ratio"     # "ratio"
     hist.stacked     = True        # stack plots
     hist.rebin       = x_labels[histogramName].binning  # rebin per histogram
-    hist.logplot     = plotLogAxis
+    hist.logplot     = {"y":False,"x":False,"data":False}
     hist.x_label     = x_labels[histogramName].label
     hist.y_label     = "Events"
     hist.y_ratio_label = "Data/MC"

--- a/python/runHistogram.py
+++ b/python/runHistogram.py
@@ -59,7 +59,7 @@ for hi,histogram in enumerate(histograms):
     hist.ratio_type  = "ratio"     # "ratio"
     hist.stacked     = True        # stack plots
     hist.rebin       = variables[histogram].binning
-    hist.logplot     = False       # plot on log scale
+    hist.logplot     = {"y":False,"x":False,"data":False}       # plot on log scale
     hist.x_label     = variables[histogram].label
     hist.y_label     = "Events"
     hist.y_ratio_label = ""


### PR DESCRIPTION
Closes #32 

Change `logplot` option in hepPlotter to be a dictionary rather than boolean.  
Support log plotting the x-/y-axes and 2D data (`logNorm` option).  

I believe I updated all the code properly, but this won't be thoroughly tested until we start running on the bug fixed samples soon.